### PR TITLE
[PIP] Add pyproject.toml to installable modules

### DIFF
--- a/l10n_fi_bank_barcode/pyproject.toml
+++ b/l10n_fi_bank_barcode/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/l10n_fi_invoice/pyproject.toml
+++ b/l10n_fi_invoice/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/l10n_fi_invoice_delivery_date/pyproject.toml
+++ b/l10n_fi_invoice_delivery_date/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"


### PR DESCRIPTION
This allows them to be editably installed with pip, and later will allow building them into installable packages.

The files were generated by running `pipx run whool init` in each module directory.

I have succesfully editably installed `l10n_fi_invoice_delivery_date` in a project.