### PR TITLE
[17.0][FIX] l10n_fi_bank_barcode: bank barcode not being computed

### DIFF
--- a/l10n_fi_bank_barcode/__manifest__.py
+++ b/l10n_fi_bank_barcode/__manifest__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "Finnish Bank Barcode",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.0.2",
     "license": "AGPL-3",
     "category": "Accounting",
     "description": """

--- a/l10n_fi_bank_barcode/models/account_move.py
+++ b/l10n_fi_bank_barcode/models/account_move.py
@@ -84,6 +84,10 @@ class InvoiceBarcode(models.Model):
             return ref.rjust(20, '0')
         return None
 
+    def _inverse_payment_reference(self):
+        super()._inverse_payment_reference()
+        self._compute_bank_barcode()
+
     # noinspection PyProtectedMember
     @api.depends('currency_id', 'amount_total', 'invoice_date_due',
                  'payment_reference', 'partner_bank_id')


### PR DESCRIPTION
When invoice in being validated via code (automatic workflow), barcode is not generated because `payment_reference` is empty. When later in the same transaction `payment_reference` is computed, `_compute_bank_barcode` is not triggered.
I suspect it's due to `payment_reference` being computed stored field without dependencies. It appears that `payment_reference` recomputation is triggered by `flush_recordset` from account.move.write(). Don't understand the whole picture, so I have to hook into `_inverse_payment_reference` to trigger manual barcode recompute.