### PR TITLE
T31479 - [MIG] invoice_sale_delivery_date from 15.0 to 17.0

### DIFF
--- a/invoice_sale_delivery_date/__manifest__.py
+++ b/invoice_sale_delivery_date/__manifest__.py
@@ -15,5 +15,5 @@
         "l10n_fi_invoice_delivery_date",
         "sale_stock",
     ],
-    "installable": False,
+    "installable": True,
 }

--- a/invoice_sale_delivery_date/tests/test_invoicing.py
+++ b/invoice_sale_delivery_date/tests/test_invoicing.py
@@ -102,8 +102,8 @@ class TestSaleExpectedDate(ValuationReconciliationTestCommon):
 
         picking = sale_order.picking_ids[0]
         for ml in picking.move_line_ids:
-            ml.qty_done = ml.product_uom_qty
-        picking._action_done()
+            ml.quantity = ml.move_id.product_uom_qty
+        picking.button_validate()
         self.assertEqual(
             picking.state,
             'done',


### PR DESCRIPTION
Migrate invoice_sale_delivery_date from 15.0 to 17.0.

Task: https://odoo.avoin.systems/web#id=33912&cids=1&model=project.task&view_type=form