### PR TITLE
[FIX][MIG] UOM field name changed

### DIFF
--- a/l10n_fi_invoice/__manifest__.py
+++ b/l10n_fi_invoice/__manifest__.py
@@ -4,7 +4,7 @@
 # noinspection PyStatementEffect
 {
     "name": "Finnish Invoice",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Avoin.Systems",
     "category": "Localization",
     "website": "https://avoin.systems",

--- a/l10n_fi_invoice/views/account_move_templates.xml
+++ b/l10n_fi_invoice/views/account_move_templates.xml
@@ -276,7 +276,7 @@
                                     </td>
                                         <td>
                                             <span t-field="l.quantity" t-if="l.display_type != 'line_note' and l.display_type != 'line_section'"/>
-                                            <span t-field="l.uom_id" groups="uom.group_uom" t-if="l.display_type != 'line_note' and l.display_type != 'line_section'"/>
+                                            <span t-field="l.product_uom_id" groups="uom.group_uom" t-if="l.display_type != 'line_note' and l.display_type != 'line_section'"/>
                                         </td>
                                         <td class="text-right">
                                             <span t-field="l.price_unit" t-if="l.display_type != 'line_note' and l.display_type != 'line_section'"/>


### PR DESCRIPTION
Field uom_id was changed to product_uom_id on move line was missed on initial migration.