### PR TITLE
[IMP] pos_marketpay: update CTA link text in Apps Store description

### DIFF
--- a/pos_marketpay/static/description/index.html
+++ b/pos_marketpay/static/description/index.html
@@ -77,7 +77,7 @@
         merchant or an international distributor, Market Pay provides the tools to succeed in the European
         market.
       </p>
-      <p><a href="https://market-pay.com/en/contact" rel="noopener">Get in touch now</a></p>
+      <p><a href="https://market-pay.com/en/contact" rel="noopener">Get in touch now &rarr; https://market-pay.com/en/contact</a></p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary

- Updates the call-to-action link text on the [Odoo Apps Store listing](https://apps.odoo.com/apps/modules/19.0/pos_marketpay) from "Get in touch now" to "Get in touch now → https://market-pay.com/en/contact"
- Makes the contact URL visible directly in the link label so readers can see the destination at a glance

## Test plan

- [ ] Verify the change renders correctly on the Odoo Apps Store page after republishing

Made with [Cursor](https://cursor.com)